### PR TITLE
Refactor Client package into HTTP Middleware

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 JustWatch
+Copyright (c) 2017 JustWatch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/seo4ajax.go
+++ b/seo4ajax.go
@@ -33,12 +33,13 @@ var (
 
 // Config is the Seo4Ajax Client config
 type Config struct {
-	Log     log.Logger
-	Next    http.Handler
-	Server  string        // seo4ajax api server, defaults to http://api.seo4ajax.com
-	Token   string        // seo4ajax token, must be set
-	IP      string        // server IP, defaults to 127.0.0.1
-	Timeout time.Duration // retry timeout, defaults to 30s
+	Log       log.Logger
+	Next      http.Handler
+	Transport http.RoundTripper
+	Server    string        // seo4ajax api server, defaults to http://api.seo4ajax.com
+	Token     string        // seo4ajax token, must be set
+	IP        string        // server IP, defaults to 127.0.0.1
+	Timeout   time.Duration // retry timeout, defaults to 30s
 }
 
 // Client is the Seo4Ajax Client
@@ -69,6 +70,9 @@ func New(cfg Config) (*Client, error) {
 	if cfg.Timeout < time.Second {
 		cfg.Timeout = 30 * time.Second
 	}
+	if cfg.Transport == nil {
+		cfg.Transport = http.DefaultTransport
+	}
 
 	c := &Client{
 		log:     cfg.Log,
@@ -82,6 +86,7 @@ func New(cfg Config) (*Client, error) {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return errRedirect
 		},
+		Transport: cfg.Transport,
 	}
 	return c, nil
 }

--- a/seo4ajax.go
+++ b/seo4ajax.go
@@ -8,118 +8,171 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/go-kit/kit/log"
 )
 
 var (
+	// ErrNoToken is returned when the client isn't provided a API token
 	ErrNoToken = errors.New("no token given")
 	// seo4ajax responded with a cache miss
-	ErrCacheMiss = errors.New("cache miss from seo4ajax")
-	errRedirect  = errors.New("SEO4AJAX: do not follow redirect")
+	ErrCacheMiss     = errors.New("cache miss from seo4ajax")
+	ErrUnknownStatus = fmt.Errorf("Unkonwn Status Code")
+	errRedirect      = errors.New("SEO4AJAX: do not follow redirect")
 
 	regexInvalidUserAgent = regexp.MustCompile(`(?i:google.*bot|bing|msnbot|yandexbot|pinterest.*ios|mail\.ru)`)
 	regexValidUserAgent   = regexp.MustCompile(`(?i:bot|crawler|spider|archiver|pinterest|facebookexternalhit|flipboardproxy)`)
 	regexPath             = regexp.MustCompile(`.*(\.[^?]{2,4}$|\.[^?]{2,4}?.*)`)
-
-	client = &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error { return errRedirect },
-	}
 )
 
-type Client struct {
-	APIHost         string
-	serverIP, token string
+// Config is the Seo4Ajax Client config
+type Config struct {
+	Log     log.Logger
+	Next    http.Handler
+	Server  string        // seo4ajax api server, defaults to http://api.seo4ajax.com
+	Token   string        // seo4ajax token, must be set
+	IP      string        // server IP, defaults to 127.0.0.1
+	Timeout time.Duration // retry timeout, defaults to 30s
 }
 
-func New(serverIP, token string) (*Client, error) {
-	if serverIP == "" || net.ParseIP(serverIP) == nil {
-		return nil, errors.New("no ip address")
-	}
+// Client is the Seo4Ajax Client
+type Client struct {
+	log     log.Logger
+	next    http.Handler
+	server  string
+	token   string
+	ip      string
+	timeout time.Duration
+	http    *http.Client
+}
 
-	if token == "" {
+// New creates a new Seo4Ajax client. Returns an error if no token is provided
+func New(cfg Config) (*Client, error) {
+	if cfg.Log == nil {
+		cfg.Log = log.NewNopLogger()
+	}
+	if cfg.Server == "" {
+		cfg.Server = "http://api.seo4ajax.com"
+	}
+	if cfg.Token == "" {
 		return nil, ErrNoToken
 	}
+	if cfg.IP == "" {
+		cfg.IP = "127.0.0.1"
+	}
+	if cfg.Timeout < time.Second {
+		cfg.Timeout = 30 * time.Second
+	}
 
-	return &Client{
-		APIHost:  "http://api.seo4ajax.com",
-		serverIP: serverIP,
-		token:    token,
-	}, nil
+	c := &Client{
+		log:     cfg.Log,
+		server:  cfg.Server,
+		token:   cfg.Token,
+		ip:      cfg.IP,
+		timeout: cfg.Timeout,
+		next:    cfg.Next,
+	}
+	c.http = &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errRedirect
+		},
+	}
+	return c, nil
 }
 
 // IsPrerender returns true, when Seo4Ajax shall be used for the given http Request.
 // The logic is taken from https://github.com/seo4ajax/connect-s4a/blob/master/lib/connect-s4a.js
-func IsPrerender(req *http.Request) (usePrerender bool) {
-	if req.Method != "GET" && req.Method != "HEAD" {
+func IsPrerender(r *http.Request) bool {
+	if r.Method != "GET" && r.Method != "HEAD" {
 		return false
 	}
 
-	if strings.Contains(req.URL.RawQuery, "_escaped_fragment_") {
+	if strings.Contains(r.URL.RawQuery, "_escaped_fragment_") {
 		return true
 	}
 
-	if regexInvalidUserAgent.MatchString(req.Header.Get("User-Agent")) {
+	if regexInvalidUserAgent.MatchString(r.Header.Get("User-Agent")) {
 		return false
 	}
 
-	if regexPath.MatchString(req.URL.Path) {
+	if regexPath.MatchString(r.URL.Path) {
 		return false
 	}
 
-	return regexValidUserAgent.MatchString(req.Header.Get("User-Agent"))
+	return regexValidUserAgent.MatchString(r.Header.Get("User-Agent"))
 }
 
-// GetPrerenderedPage returns the prerendered html from the seo4ajax api. If no
-// token is given, it will return an error.
-func (c *Client) GetPrerenderedPage(w http.ResponseWriter, req *http.Request) (err error) {
-	var prerenderRequest *http.Request
-	prerenderRequest, err = http.NewRequest("GET", fmt.Sprintf("%s/%s%s", c.APIHost, c.token, cleanPath(req.URL)), nil)
-	if err != nil {
+// ServeHTTP will serve the prerendered page if this is a prerender request
+// or no upstream handler is set. Otherwise it will just invoke the upstream
+// handler
+func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if IsPrerender(r) || c.next == nil {
+		c.GetPrerenderedPage(w, r)
 		return
 	}
 
-	prerenderRequest.Header = req.Header
+	c.next.ServeHTTP(w, r)
+	return
+}
 
-	xForwardedFor := req.Header.Get("X-Forwarded-For")
-	if xForwardedFor != "" {
-		xForwardedFor = fmt.Sprintf("%s, %s", c.serverIP, xForwardedFor)
-	} else {
-		xForwardedFor = c.serverIP
-	}
-	prerenderRequest.Header.Set("X-Forwarded-For", xForwardedFor)
+// GetPrerenderedPage returns the prerendered html from the seo4ajax api
+func (c *Client) GetPrerenderedPage(w http.ResponseWriter, r *http.Request) {
+	opFunc := func() error {
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s%s", c.server, c.token, cleanPath(r.URL)), nil)
+		if err != nil {
+			return err
+		}
 
-	var resp *http.Response
-	resp, err = client.Do(prerenderRequest)
-	if err != nil && !strings.HasSuffix(err.Error(), errRedirect.Error()) {
-		return
-	} else {
-		err = nil
-	}
-	defer resp.Body.Close()
+		req.Header = r.Header
+		ips := []string{c.ip}
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			ips = append(ips, xff)
+		}
+		req.Header.Set("X-Forwarded-For", strings.Join(ips, ", "))
 
-	switch resp.StatusCode {
-	case 200:
+		resp, err := c.http.Do(req)
+		if err != nil && !strings.HasSuffix(err.Error(), errRedirect.Error()) {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusFound {
+			http.Redirect(w, r, resp.Header.Get("Location"), http.StatusFound)
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			// retry
+			return err
+		}
+
 		for header, val := range resp.Header {
 			w.Header()[header] = val
 		}
 
+		// as soon as we start writing the body we must return nil, otherwise we'll
+		// mess up the HTTP response by calling response.WriteHeader multiple times
 		_, err = io.Copy(w, resp.Body)
-	case 302:
-		http.Redirect(w, req, resp.Header.Get("Location"), resp.StatusCode)
-	case 401, 403:
-		err = ErrNoToken
-	case 503:
-		err = ErrCacheMiss
+		if err != nil {
+			c.log.Log("level", "warning", "msg", "Failed to copy request", "err", err)
+		}
+		return nil
 	}
 
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 50 * time.Millisecond
+	bo.MaxInterval = 30 * time.Second
+	bo.MaxElapsedTime = c.timeout
+	err := backoff.Retry(opFunc, bo)
 	if err != nil {
-		http.Error(w, err.Error(), 503)
+		c.log.Log("level", "warning", "msg", "Upstream request failed", "err", err)
 	}
-
 	return
 }
 

--- a/seo4ajax.go
+++ b/seo4ajax.go
@@ -114,8 +114,10 @@ func IsPrerender(r *http.Request) bool {
 }
 
 // ServeHTTP will serve the prerendered page if this is a prerender request.
-// If no upstream handler is set it will return an error.
-// Otherwise it will just invoke the upstream handler
+// If no upstream handler is set it will return an error. Otherwise it will
+// just invoke the upstream handler. This way it can be either used as an
+// HTTP middleware intercepting any prerender requests or an regular HTTP
+// handler (if next is nil) to serve only prerender request
 func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if IsPrerender(r) {
 		c.GetPrerenderedPage(w, r)

--- a/seo4ajax_test.go
+++ b/seo4ajax_test.go
@@ -245,17 +245,20 @@ func TestIsPrerender(t *testing.T) {
 				}))
 				defer ts.Close()
 
-				seo4ajaxClient, err := New(serverIP, token)
+				seo4ajaxClient, err := New(Config{
+					IP:     serverIP,
+					Token:  token,
+					Server: ts.URL,
+				})
 				So(err, ShouldBeNil)
 				So(seo4ajaxClient, ShouldNotBeNil)
-				seo4ajaxClient.APIHost = "http://" + ts.Listener.Addr().String()
 
 				req, err := http.NewRequest("GET", "http://"+appAdress+"/path?param1=val1&_escaped_fragment_=", nil)
 				So(err, ShouldBeNil)
 				So(req, ShouldNotBeNil)
 				So(IsPrerender(req), ShouldBeTrue)
 				recorder := httptest.NewRecorder()
-				err = seo4ajaxClient.GetPrerenderedPage(recorder, req)
+				seo4ajaxClient.ServeHTTP(recorder, req)
 				So(err, ShouldBeNil)
 			})
 		})
@@ -270,10 +273,13 @@ func TestIsPrerender(t *testing.T) {
 				}))
 				defer ts.Close()
 
-				seo4ajaxClient, err := New(serverIP, token)
+				seo4ajaxClient, err := New(Config{
+					IP:     serverIP,
+					Token:  token,
+					Server: ts.URL,
+				})
 				So(err, ShouldBeNil)
 				So(seo4ajaxClient, ShouldNotBeNil)
-				seo4ajaxClient.APIHost = "http://" + ts.Listener.Addr().String()
 
 				req, err := http.NewRequest("GET", "http://"+appAdress+"/path?param1=val1&_escaped_fragment_=", nil)
 				req.Header.Add("content-type", "content-type")
@@ -282,7 +288,7 @@ func TestIsPrerender(t *testing.T) {
 				So(req, ShouldNotBeNil)
 				So(IsPrerender(req), ShouldBeTrue)
 				recorder := httptest.NewRecorder()
-				err = seo4ajaxClient.GetPrerenderedPage(recorder, req)
+				seo4ajaxClient.ServeHTTP(recorder, req)
 				So(err, ShouldBeNil)
 			})
 		})
@@ -295,17 +301,20 @@ func TestIsPrerender(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			seo4ajaxClient, err := New(serverIP, token)
+			seo4ajaxClient, err := New(Config{
+				IP:     serverIP,
+				Token:  token,
+				Server: ts.URL,
+			})
 			So(err, ShouldBeNil)
 			So(seo4ajaxClient, ShouldNotBeNil)
-			seo4ajaxClient.APIHost = "http://" + ts.Listener.Addr().String()
 
 			req, err := http.NewRequest("GET", "http://"+appAdress+"/?_escaped_fragment_=", nil)
 			So(err, ShouldBeNil)
 			So(req, ShouldNotBeNil)
 			So(IsPrerender(req), ShouldBeTrue)
 			recorder := httptest.NewRecorder()
-			err = seo4ajaxClient.GetPrerenderedPage(recorder, req)
+			seo4ajaxClient.ServeHTTP(recorder, req)
 			So(err, ShouldBeNil)
 		})
 
@@ -317,10 +326,13 @@ func TestIsPrerender(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			seo4ajaxClient, err := New(serverIP, token)
+			seo4ajaxClient, err := New(Config{
+				IP:     serverIP,
+				Token:  token,
+				Server: ts.URL,
+			})
 			So(err, ShouldBeNil)
 			So(seo4ajaxClient, ShouldNotBeNil)
-			seo4ajaxClient.APIHost = "http://" + ts.Listener.Addr().String()
 
 			req, err := http.NewRequest("GET", "http://"+appAdress+"/?_escaped_fragment_=", nil)
 			req.Header.Add("x-forwarded-for", "10.0.0.2, 10.0.0.1")
@@ -328,7 +340,7 @@ func TestIsPrerender(t *testing.T) {
 			So(req, ShouldNotBeNil)
 			So(IsPrerender(req), ShouldBeTrue)
 			recorder := httptest.NewRecorder()
-			err = seo4ajaxClient.GetPrerenderedPage(recorder, req)
+			seo4ajaxClient.ServeHTTP(recorder, req)
 			So(err, ShouldBeNil)
 		})
 	})
@@ -341,10 +353,13 @@ func TestIsPrerender(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		seo4ajaxClient, err := New(serverIP, token)
+		seo4ajaxClient, err := New(Config{
+			IP:     serverIP,
+			Token:  token,
+			Server: ts.URL,
+		})
 		So(err, ShouldBeNil)
 		So(seo4ajaxClient, ShouldNotBeNil)
-		seo4ajaxClient.APIHost = "http://" + ts.Listener.Addr().String()
 
 		req, err := http.NewRequest("GET", "http://"+appAdress+"/?_escaped_fragment_=", nil)
 		So(err, ShouldBeNil)
@@ -352,7 +367,7 @@ func TestIsPrerender(t *testing.T) {
 		So(IsPrerender(req), ShouldBeTrue)
 
 		recorder := httptest.NewRecorder()
-		err = seo4ajaxClient.GetPrerenderedPage(recorder, req)
+		seo4ajaxClient.ServeHTTP(recorder, req)
 
 		So(err, ShouldBeNil)
 		So(recorder.Header().Get("Location"), ShouldEqual, "http://example.com/")
@@ -360,7 +375,9 @@ func TestIsPrerender(t *testing.T) {
 	})
 
 	Convey("returns error if no token", t, func() {
-		seo4ajaxClient, err := New(serverIP, "")
+		seo4ajaxClient, err := New(Config{
+			IP: serverIP,
+		})
 		So(seo4ajaxClient, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, ErrNoToken)


### PR DESCRIPTION
This PR refactors the client package to look and feel as an net/http.Handler.

The package can be used as before using `IsPrerender` and `GetPrerenderedPage` or it can be mounted as an HTTP middleware which will automatically call `IsPrerender` and, if necessary, `GetPrerenderedPage`.