### PR TITLE
add config option to enable unconditional fetching

### DIFF
--- a/seo4ajax.go
+++ b/seo4ajax.go
@@ -179,9 +179,6 @@ func (c *Client) GetPrerenderedPage(w http.ResponseWriter, r *http.Request) {
 		// as soon as we start writing the body we must return nil, otherwise we'll
 		// mess up the HTTP response by calling response.WriteHeader multiple times
 		_, err = io.Copy(w, resp.Body)
-		if err == nil {
-			w.WriteHeader(resp.StatusCode)
-		}
 		return err
 	}
 
@@ -189,11 +186,9 @@ func (c *Client) GetPrerenderedPage(w http.ResponseWriter, r *http.Request) {
 	bo.InitialInterval = 50 * time.Millisecond
 	bo.MaxInterval = 30 * time.Second
 	bo.MaxElapsedTime = c.timeout
-	err := backoff.RetryNotify(opFunc, bo, func(e error, duration time.Duration) {
-		c.log.Log("level", "warn", "msg", "Upstream request failed, retrying ...", "err", e)
-	})
+	err := backoff.Retry(opFunc, bo)
 	if err != nil {
-		c.log.Log("level", "warn", "msg", "Upstream request finally failed", "err", err)
+		c.log.Log("level", "warn", "msg", "Upstream request failed", "err", err)
 		if !outputStarted {
 			http.Error(w, "Upstream error", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
This PR addresses #2. S4A may return empty responses with a 304 status code if conditional headers
`If-None-Match` and/or `If-Modified-Since` are set